### PR TITLE
Sanitize tar

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Create an archive file containing the contents of directory src
@@ -58,6 +59,10 @@ func Extract(reader io.Reader) ([]string, error) {
 		// the following switch could also be done using fi.Mode(), not sure if there
 		// a benefit of using one vs. the other.
 		// fi := header.FileInfo()
+
+		if strings.Contains(target, "..") {
+			return nil, fmt.Errorf("path contains ..: %s", target)
+		}
 
 		// check the file type
 		switch header.Typeflag {

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -1,0 +1,102 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hermo/npmi-go/pkg/files"
+)
+
+func Test_ExtractFilesNormal(t *testing.T) {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	tarContents := []struct {
+		Name    string
+		Content string
+		Type    byte
+	}{
+		{"root.txt", "rootfile", tar.TypeReg},
+		{"somedir", "", tar.TypeDir},
+		{"somedir/sub.txt", "subfile", tar.TypeReg},
+	}
+
+	for _, f := range tarContents {
+		data := []byte(f.Content)
+		hdr := tar.Header{
+			Typeflag: f.Type,
+			Name:     f.Name,
+		}
+		if f.Type == tar.TypeReg {
+			hdr.Size = int64(len(data))
+		}
+		tw.WriteHeader(&hdr)
+		if f.Type == tar.TypeReg {
+			tw.Write(data)
+		}
+	}
+
+	tw.Close()
+	gzw.Close()
+
+	testDataDir, err := filepath.Abs("../../testdata")
+	if err != nil {
+		t.Fatalf("Can't find test directory: %v", err)
+	}
+
+	testDir, err := os.MkdirTemp(testDataDir, "test")
+	if err != nil {
+		t.Fatalf("Can't create temporary test directory: %v", err)
+	}
+
+	defer func() {
+		os.Chdir("../..")
+		err := os.RemoveAll(testDir)
+		if err != nil {
+			t.Fatalf("Could not remove temp directory: %v", err)
+		}
+	}()
+
+	err = os.Chdir(testDir)
+	if err != nil {
+		t.Fatalf("Can't chdir to test directory: %v", err)
+	}
+
+	err = os.Mkdir("extract", 0700)
+	if err != nil {
+		t.Fatalf("Could not create directory: %v", err)
+	}
+
+	err = os.Chdir("extract")
+	if err != nil {
+		t.Fatalf("Can't chdir to test directory: %v", err)
+	}
+
+	manifest, err := Extract(&buf)
+	if err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	wantManifestLen := 2
+	if len(manifest) != wantManifestLen {
+		t.Fatalf("Manifest length=%d,want=%d", len(manifest), wantManifestLen)
+	}
+
+	for _, f := range tarContents {
+		if f.Type != tar.TypeReg {
+			continue
+		}
+		exists, err := files.IsExistingFile(f.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatalf("File %s should exists but does not", f.Name)
+		}
+	}
+}

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -4,12 +4,23 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/hermo/npmi-go/pkg/files"
 )
+
+func getBaseDir() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("No caller information")
+	}
+	return path.Dir(filename)
+}
 
 func Test_ExtractFilesNormal(t *testing.T) {
 	var buf bytes.Buffer
@@ -44,18 +55,18 @@ func Test_ExtractFilesNormal(t *testing.T) {
 	tw.Close()
 	gzw.Close()
 
-	testDataDir, err := filepath.Abs("../../testdata")
+	testBaseDir, err := filepath.Abs(fmt.Sprintf("%s/../../testdata", getBaseDir()))
 	if err != nil {
 		t.Fatalf("Can't find test directory: %v", err)
 	}
 
-	testDir, err := os.MkdirTemp(testDataDir, "test")
+	testDir, err := os.MkdirTemp(testBaseDir, "test")
 	if err != nil {
 		t.Fatalf("Can't create temporary test directory: %v", err)
 	}
 
 	defer func() {
-		os.Chdir("../..")
+		os.Chdir(getBaseDir())
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Fatalf("Could not remove temp directory: %v", err)
@@ -97,6 +108,77 @@ func Test_ExtractFilesNormal(t *testing.T) {
 		}
 		if !exists {
 			t.Fatalf("File %s should exists but does not", f.Name)
+		}
+	}
+}
+
+func Test_ExtractFilesEvil(t *testing.T) {
+	evilPayloads := []struct {
+		Name    string
+		Content string
+		Type    byte
+	}{
+		{"../evil.txt", "evil", tar.TypeReg},
+		{"./../evil.txt", "evil", tar.TypeReg},
+	}
+
+	testBaseDir, err := filepath.Abs(fmt.Sprintf("%s/../../testdata", getBaseDir()))
+	if err != nil {
+		t.Fatalf("Can't find test data directory: %v", err)
+	}
+
+	for _, f := range evilPayloads {
+		testDir, err := os.MkdirTemp(testBaseDir, "test")
+		if err != nil {
+			t.Fatalf("Can't create temporary test directory: %v", err)
+		}
+
+		defer func() {
+			os.Chdir(getBaseDir())
+			err := os.RemoveAll(testDir)
+			if err != nil {
+				t.Fatalf("Could not remove temp directory: %v", err)
+			}
+		}()
+
+		err = os.Chdir(testDir)
+		if err != nil {
+			t.Fatalf("Can't chdir to test directory: %v", err)
+		}
+
+		err = os.Mkdir("extract", 0700)
+		if err != nil {
+			t.Fatalf("Could not create directory: %v", err)
+		}
+
+		err = os.Chdir("extract")
+		if err != nil {
+			t.Fatalf("Can't chdir to test directory: %v", err)
+		}
+
+		var buf bytes.Buffer
+		gzw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gzw)
+
+		data := []byte(f.Content)
+		hdr := tar.Header{
+			Typeflag: f.Type,
+			Name:     f.Name,
+		}
+		if f.Type == tar.TypeReg {
+			hdr.Size = int64(len(data))
+		}
+		tw.WriteHeader(&hdr)
+		if f.Type == tar.TypeReg {
+			tw.Write(data)
+		}
+
+		tw.Close()
+		gzw.Close()
+
+		_, err = Extract(&buf)
+		if err == nil {
+			t.Fatalf("Extract should have failed but did not")
 		}
 	}
 }


### PR DESCRIPTION
Fixes "Zip Slip" issue detected by CodeQL by adding some validity checks to archive extraction.
The validation is not foolproof. However, attacks via corrupted cache items would require a bad actor to already have access to the archive store.