### PR TITLE
Add symlink support

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -110,16 +110,14 @@ func Extract(reader io.Reader) ([]string, error) {
 			source := filepath.ToSlash(header.Linkname)
 
 			if source[0] == '/' {
-				fmt.Printf("WARN: skipping symlink with absolute path: %s -> %s\n", dest, source)
-				continue
+				return nil, fmt.Errorf("invalid path: symlink with absolute path: %s -> %s", dest, source)
 			}
 
 			dir := filepath.Dir(dest)
 			resolvedTarget := filepath.Join(dir, source)
 
 			if !strings.HasPrefix(resolvedTarget, cwd) {
-				fmt.Printf("WARN: %s -> %s points outside cwd\n", reldest, source)
-				continue
+				return nil, fmt.Errorf("invalid path: %s -> %s points outside cwd", reldest, source)
 			}
 
 			err = syncSymLink(source, dest)

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -161,6 +161,8 @@ func Test_ExtractFilesEvil(t *testing.T) {
 		{"CON", "evil", tar.TypeReg},
 		{"NUL", "evil", tar.TypeReg},
 		{"C:\\Users\\Public\\evil2.txt", "evil2", tar.TypeReg},
+		{"abs_link", "/etc/passwd", tar.TypeSymlink},
+		{"outside_link", "../outside_cwd", tar.TypeSymlink},
 	}
 
 	testBaseDir, err := filepath.Abs(fmt.Sprintf("%s/../../testdata", getBaseDir()))
@@ -211,6 +213,9 @@ func Test_ExtractFilesEvil(t *testing.T) {
 		}
 		if f.Type == tar.TypeReg {
 			hdr.Size = int64(len(data))
+		}
+		if f.Type == tar.TypeSymlink {
+			hdr.Linkname = f.Content
 		}
 		err = tw.WriteHeader(&hdr)
 		if err != nil {

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -47,9 +47,7 @@ func RemoveFilesNotPresentInManifest(directory string, filesTokeep []string) (in
 			return err
 		}
 
-		// return on non-regular files (thanks to [kumo](https://medium.com/@komuw/just-like-you-did-fbdd7df829d3) for this suggested update)
-		// TODO: Add link support
-		if !fi.Mode().IsRegular() {
+		if !(fi.Mode().IsRegular() || fi.Mode()&os.ModeSymlink != 0) {
 			return nil
 		}
 

--- a/testdata/package-lock.json
+++ b/testdata/package-lock.json
@@ -8,6 +8,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     }
   }
 }

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "left-pad": "^1.3.0"
+    "left-pad": "^1.3.0",
+    "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
Symlinks are used quite a bit in node packages. This PR adds support for symlinks.

Some attempts have been made to avoid obvious security issues but the implementation is certainly not bulletproof.

The threat model of npmi-go assumes that cache contents are trustworthy, which is my excuse for not spending more time hardening the symlink support.