### PR TITLE
Performance optimizations

### DIFF
--- a/bench/compress/.gitignore
+++ b/bench/compress/.gitignore
@@ -1,0 +1,6 @@
+/node_modules/
+*.log
+*.last
+*.prof
+*.test
+*.json

--- a/bench/extract/.gitattributes
+++ b/bench/extract/.gitattributes
@@ -1,0 +1,1 @@
+test.tgz filter=lfs diff=lfs merge=lfs -text

--- a/bench/extract/.gitignore
+++ b/bench/extract/.gitignore
@@ -1,0 +1,6 @@
+/node_modules/
+*.log
+*.last
+*.prof
+*.test
+*.json

--- a/bench/extract/test.tgz
+++ b/bench/extract/test.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd19a875630e83fafe3a248e7aa4a363ffb0a974d32bdfc2f383ae97be905166
+size 24897127

--- a/bench/run
+++ b/bench/run
@@ -2,14 +2,16 @@
 
 set -euo pipefail
 
-if [ $# -lt 2 ]; then
-  echo "Usage: run <PACKAGE> <DESCRIPTION>"
-  echo "PACKAGE is something like ../../pkg/archive".
+if [ $# -lt 3 ]; then
+  echo "Usage: run <PACKAGE> <BENCH-FILTER> <DESCRIPTION>"
+  echo "PACKAGE is something like ../../pkg/archive"
+  echo "BENCH-FILTER is something like . (to run every benchmark) or 'Extract' to only run the Extraction test"
   exit 1
 fi
 
 pkg="$1"
-descr="${*:2}"
+filter="$2"
+descr="${*:3}"
 
 if [ -f bench.last ]; then
   n=$(( $(cat bench.last) + 1 ))
@@ -20,5 +22,5 @@ fi
 runid="$(printf '%02d' $n)"
 echo "$runid" > bench.last
 printf "%s run-%s %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$runid" "$descr" >> bench.log
-go test "$pkg" -bench=. -run=xxx -benchmem -memprofile ${runid}_mem.prof -cpuprofile ${runid}_cpu.prof -benchtime=10s | tee $runid.log
+go test "$pkg" -bench="$filter" -run=xxx -benchmem -memprofile ${runid}_mem.prof -cpuprofile ${runid}_cpu.prof -benchtime=10s | tee $runid.log
 printf "Run %s complete\n" "$runid"

--- a/bench/run
+++ b/bench/run
@@ -20,7 +20,9 @@ else
 fi
 
 runid="$(printf '%02d' $n)"
-echo "$runid" > bench.last
 printf "%s run-%s %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$runid" "$descr" >> bench.log
 go test "$pkg" -bench="$filter" -run=xxx -benchmem -memprofile ${runid}_mem.prof -cpuprofile ${runid}_cpu.prof -benchtime=10s | tee $runid.log
 printf "Run %s complete\n" "$runid"
+
+# Increment run counter only after everything else is done
+echo "$runid" > bench.last

--- a/bench/run
+++ b/bench/run
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: run <PACKAGE> <DESCRIPTION>"
+  echo "PACKAGE is something like ../../pkg/archive".
+  exit 1
+fi
+
+pkg="$1"
+descr="${*:2}"
+
+if [ -f bench.last ]; then
+  n=$(( $(cat bench.last) + 1 ))
+else
+  n=0
+fi
+
+runid="$(printf '%02d' $n)"
+echo "$runid" > bench.last
+printf "%s run-%s %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$runid" "$descr" >> bench.log
+go test "$pkg" -bench=. -run=xxx -benchmem -memprofile ${runid}_mem.prof -cpuprofile ${runid}_cpu.prof -benchtime=10s | tee $runid.log
+printf "Run %s complete\n" "$runid"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/caarlos0/env/v6 v6.9.3
 	github.com/hashicorp/go-hclog v1.2.2
+	github.com/klauspost/pgzip v1.2.5
 	github.com/minio/minio-go/v7 v7.0.34
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
+github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -54,6 +54,34 @@ func (bp *badpath) IsBad(path string) bool {
 	return bp.re.MatchString(path)
 }
 
+func (bp *badpath) IsBad2(path string) bool {
+	if strings.ContainsAny(path, "<|>:\"*?\\") {
+		return true
+	}
+
+	if !bp.allowDoubleDot {
+		if strings.Contains(path, "..") {
+			return true
+		}
+	}
+	bad := []string{"/", "CON", "PRN", "AUX", "NUL"}
+	for _, s := range bad {
+		if strings.HasPrefix(path, s) {
+			return true
+		}
+	}
+	semibad := []string{"COM", "LPT"}
+	for _, s := range semibad {
+		if strings.HasPrefix(path, s) && len(path) > 3 {
+			if path[3] >= '1' && path[3] <= '9' {
+				return true
+			}
+		}
+	}
+	// return bp.re.MatchString(path)
+	return false
+}
+
 // Extract all files from an archive to current directory
 func Extract(reader io.Reader) ([]string, error) {
 	cwd, err := os.Getwd()

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -193,15 +193,13 @@ func Extract(reader io.Reader) ([]string, error) {
 }
 
 // createTarGz writes a given directory tree to a Gzipped TAR
-func createTarGz(src string, writers ...io.Writer) error {
+func createTarGz(src string, w io.Writer) error {
 
 	if _, err := os.Stat(src); err != nil {
 		return fmt.Errorf("TAR: %v", err.Error())
 	}
 
-	mw := io.MultiWriter(writers...)
-
-	gzw := pgzip.NewWriter(mw)
+	gzw := pgzip.NewWriter(w)
 	defer gzw.Close()
 
 	tw := tar.NewWriter(gzw)

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -57,8 +57,8 @@ func (bp *badpath) IsBad(path string) bool {
 	}
 
 	path = strings.ToUpper(path)
-	windowDevices := []string{"CON", "PRN", "AUX", "NUL"}
-	for _, s := range windowDevices {
+	windowsDevices := []string{"CON", "PRN", "AUX", "NUL"}
+	for _, s := range windowsDevices {
 		if path == s {
 			return true
 		}

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -47,14 +47,25 @@ func (bp *badpath) IsBad(path string) bool {
 			return true
 		}
 	}
-	bad := []string{"/", "CON", "PRN", "AUX", "NUL"}
-	for _, s := range bad {
-		if strings.HasPrefix(path, s) {
+
+	if path[0] == '/' {
+		return true
+	}
+
+	if strings.HasPrefix(path, " ") {
+		return true
+	}
+
+	path = strings.ToUpper(path)
+	windowDevices := []string{"CON", "PRN", "AUX", "NUL"}
+	for _, s := range windowDevices {
+		if path == s {
 			return true
 		}
 	}
-	semibad := []string{"COM", "LPT"}
-	for _, s := range semibad {
+
+	windowsDevicePrefixes := []string{"COM", "LPT"}
+	for _, s := range windowsDevicePrefixes {
 		if strings.HasPrefix(path, s) && len(path) > 3 {
 			if path[3] >= '1' && path[3] <= '9' {
 				return true

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -2,7 +2,6 @@ package archive
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -202,7 +201,7 @@ func createTarGz(src string, writers ...io.Writer) error {
 
 	mw := io.MultiWriter(writers...)
 
-	gzw := gzip.NewWriter(mw)
+	gzw := pgzip.NewWriter(mw)
 	defer gzw.Close()
 
 	tw := tar.NewWriter(gzw)

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -130,19 +130,18 @@ func Extract(reader io.Reader) ([]string, error) {
 
 			// copy over contents
 			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
 				return nil, err
 			}
 
 			// manually close here after each file operation; defering would cause each file close
 			// to wait until all operations have completed.
 			f.Close()
-			err = os.Chtimes(target, time.Now(), header.FileInfo().ModTime())
-			if err != nil {
+			if err = os.Chtimes(target, time.Now(), header.FileInfo().ModTime()); err != nil {
 				return nil, err
 			}
 
-			err = os.Chmod(target, header.FileInfo().Mode())
-			if err != nil {
+			if err = os.Chmod(target, header.FileInfo().Mode()); err != nil {
 				return nil, err
 			}
 

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -29,32 +28,14 @@ func Create(filename string, src string) error {
 }
 
 type badpath struct {
-	re             *regexp.Regexp
 	allowDoubleDot bool
 }
 
 func NewBadPath(allowDoubleDot bool) *badpath {
-	// Match known evil characters
-	// Windows bad chars and devices from https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
-	var re *regexp.Regexp
-	var err error
-	if allowDoubleDot {
-		re, err = regexp.Compile("(<|>|:|\"|\\||\\?|\\*|^/|^CON|^PRN|^AUX|^NUL|^COM1|^COM2|^COM3|^COM4|^COM5|^COM6|^COM7|^COM8|^COM9|^LPT1|^LPT2|^LPT3|^LPT4|^LPT5|^LPT6|^LPT7|^LPT8|^LPT9)")
-	} else {
-		re, err = regexp.Compile("(<|>|:|\"|\\||\\?|\\*|\\.\\.|^/|^CON|^PRN|^AUX|^NUL|^COM1|^COM2|^COM3|^COM4|^COM5|^COM6|^COM7|^COM8|^COM9|^LPT1|^LPT2|^LPT3|^LPT4|^LPT5|^LPT6|^LPT7|^LPT8|^LPT9)")
-	}
-	if err != nil {
-		panic(err)
-	}
-
-	return &badpath{re, allowDoubleDot}
+	return &badpath{allowDoubleDot}
 }
 
 func (bp *badpath) IsBad(path string) bool {
-	return bp.re.MatchString(path)
-}
-
-func (bp *badpath) IsBad2(path string) bool {
 	if strings.ContainsAny(path, "<|>:\"*?\\") {
 		return true
 	}
@@ -78,7 +59,6 @@ func (bp *badpath) IsBad2(path string) bool {
 			}
 		}
 	}
-	// return bp.re.MatchString(path)
 	return false
 }
 

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/klauspost/pgzip"
 )
 
 // Create an archive file containing the contents of directory src
@@ -70,7 +72,7 @@ func Extract(reader io.Reader) ([]string, error) {
 	}
 
 	var manifest []string
-	gzr, err := gzip.NewReader(reader)
+	gzr, err := pgzip.NewReaderN(reader, 500e3, 50)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -347,7 +347,7 @@ func removeTestDir(testDir string) {
 	}
 }
 
-func BenchmarkExtraFiles(b *testing.B) {
+func BenchmarkExtract(b *testing.B) {
 	testDir, err := prepareTestDir()
 	if err != nil {
 		b.Fatalf("Can't create temporary test directory: %v", err)

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -430,9 +430,6 @@ func TestBadPath(t *testing.T) {
 			if bp.IsBad(tt.Path) != tt.Expected {
 				t.Errorf("IsBad(%s) did not return %v", tt.Path, tt.Expected)
 			}
-			if bp.IsBad2(tt.Path) != tt.Expected {
-				t.Errorf("IsBad2(%s) did not return %v", tt.Path, tt.Expected)
-			}
 		})
 	}
 }
@@ -442,13 +439,5 @@ func BenchmarkBadPath(b *testing.B) {
 	path := "node_modules/foo_bar/baz.js/somepath"
 	for i := 0; i < b.N; i++ {
 		bp.IsBad(path)
-	}
-}
-
-func BenchmarkBadPath2(b *testing.B) {
-	bp := NewBadPath(false)
-	path := "node_modules/foo_bar/baz.js/somepath"
-	for i := 0; i < b.N; i++ {
-		bp.IsBad2(path)
 	}
 }

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -397,7 +397,13 @@ func TestBadPath(t *testing.T) {
 		{false, "../evil2.txt", true},
 		{false, "C:/Users/Public/evil3.txt", true},
 		{false, "C:|Users/Public/evil4.txt", true},
+		{false, "<", true},
+		{false, "<foo", true},
+		{false, " <foo2", true},
+		{false, "bar>", true},
 		{false, "COM1>", true},
+		{false, "LPT3", true},
+		{false, "COM9", true},
 		{false, "CON", true},
 		{false, "NUL", true},
 		{false, "C:\\Users\\Public\\evil5.txt", true},
@@ -407,17 +413,25 @@ func TestBadPath(t *testing.T) {
 		{true, "/../evil_double_dots_61..txt", true},
 
 		// Good inputs, double dots disallowed
-		{false, "foo/bar//double_dots7.txt", false},
+		{false, "kissa7.txt", false},
+		{false, "foo/bar//double_dots71.txt", false},
+		{false, "COM0", false},
+		{false, "COM", false},
 
 		// Good inputs, double dots allowed
 		{true, "../double_dots8.txt", false},
 		{true, "double_dots9..txt", false},
+		{true, "LPT0", false},
+		{true, "LPT", false},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("allowDoubleDots: %v Path: %s", tt.allowDoubleDot, tt.Path), func(t *testing.T) {
 			bp := NewBadPath(tt.allowDoubleDot)
 			if bp.IsBad(tt.Path) != tt.Expected {
 				t.Errorf("IsBad(%s) did not return %v", tt.Path, tt.Expected)
+			}
+			if bp.IsBad2(tt.Path) != tt.Expected {
+				t.Errorf("IsBad2(%s) did not return %v", tt.Path, tt.Expected)
 			}
 		})
 	}
@@ -428,5 +442,13 @@ func BenchmarkBadPath(b *testing.B) {
 	path := "node_modules/foo_bar/baz.js/somepath"
 	for i := 0; i < b.N; i++ {
 		bp.IsBad(path)
+	}
+}
+
+func BenchmarkBadPath2(b *testing.B) {
+	bp := NewBadPath(false)
+	path := "node_modules/foo_bar/baz.js/somepath"
+	for i := 0; i < b.N; i++ {
+		bp.IsBad2(path)
 	}
 }

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -450,3 +450,47 @@ func BenchmarkBadPath(b *testing.B) {
 		bp.IsBad(path)
 	}
 }
+
+func BenchmarkCreate(b *testing.B) {
+	testDir, err := prepareTestDir()
+	if err != nil {
+		b.Fatalf("Can't create temporary test directory: %v", err)
+	}
+
+	defer removeTestDir(testDir)
+
+	err = os.Mkdir("compress", 0700)
+	if err != nil {
+		b.Fatalf("Could not create directory: %v", err)
+	}
+
+	err = os.Chdir("compress")
+	if err != nil {
+		b.Fatalf("Can't chdir to test directory: %v", err)
+	}
+	testArchive, err := filepath.Abs(fmt.Sprintf("%s/../../bench/extract/test.tgz", getBaseDir()))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	f, err := os.Open(testArchive)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	_, err = Extract(f)
+	if err != nil {
+		b.Fatalf("Extract failed: %v", err)
+	}
+	f.Close()
+
+	for i := 0; i < b.N; i++ {
+		if err = Create("compressed.tgz", "node_modules"); err != nil {
+			b.Fatalf("Create failed: %v", err)
+		}
+
+		if err = os.Remove("compressed.tgz"); err != nil {
+			b.Fatalf("Remove failed: %v", err)
+		}
+	}
+}

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -402,10 +402,14 @@ func TestBadPath(t *testing.T) {
 		{false, " <foo2", true},
 		{false, "bar>", true},
 		{false, "COM1>", true},
+		{false, "com3", true},
+		{false, "LpT7", true},
 		{false, "LPT3", true},
 		{false, "COM9", true},
+		{false, "win\\separator", true},
 		{false, "CON", true},
 		{false, "NUL", true},
+		{false, " Spaceman", true},
 		{false, "C:\\Users\\Public\\evil5.txt", true},
 
 		// Evil inputs, double dots allowed
@@ -417,15 +421,20 @@ func TestBadPath(t *testing.T) {
 		{false, "foo/bar//double_dots71.txt", false},
 		{false, "COM0", false},
 		{false, "COM", false},
+		{false, "Hello dolly", false},
 
 		// Good inputs, double dots allowed
 		{true, "../double_dots8.txt", false},
 		{true, "double_dots9..txt", false},
 		{true, "LPT0", false},
 		{true, "LPT", false},
+		{true, "COMA", false},
+		{true, "CONAIR", false},
+		{true, "NULL", false},
+		{true, "Program Files/my app.exe", false},
 	}
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("allowDoubleDots: %v Path: %s", tt.allowDoubleDot, tt.Path), func(t *testing.T) {
+		t.Run(fmt.Sprintf("allowDoubleDots:%v,Path:%s", tt.allowDoubleDot, tt.Path), func(t *testing.T) {
 			bp := NewBadPath(tt.allowDoubleDot)
 			if bp.IsBad(tt.Path) != tt.Expected {
 				t.Errorf("IsBad(%s) did not return %v", tt.Path, tt.Expected)

--- a/pkg/npmi/main.go
+++ b/pkg/npmi/main.go
@@ -199,10 +199,14 @@ func (m *main) createArchive(cacheKey string) (archiveFilename string, err error
 	archivePath := filepath.Join(m.options.TempDir, createArchiveFilename(cacheKey))
 	log.Debug("Creating archive", "path", archivePath)
 
-	err = archive.Create(archivePath, m.modulesDirectory)
+	warnings, err := archive.Create(archivePath, m.modulesDirectory)
 	if err != nil {
 		log.Error("failed", "error", err)
 		return "", err
+	}
+
+	for _, warning := range warnings {
+		log.Warn(warning)
 	}
 
 	log.Trace("complete")


### PR DESCRIPTION
This PR adds various performance optimizations.

# Improvements
- Strings-based Bad Path detection instead of Regular expressions
- Using optimized Parallel Gzip decompression

# Configuration
- -minio=0
- -local=1

# Results
Most of the performance improvements come from using a parallel Gzip implementation and probably won't be this pronounced in a resource-restricted CI container.

## Cache MISS performance improvements

```
npmi-go/bench/compress$ NODE_ENV=production hyperfine -w 2 '../../npmi-go.old -force' '../../npmi-go.new -force'
Benchmark 1: ../../npmi-go.old -force
  Time (mean ± σ):     25.578 s ±  0.620 s    [User: 28.066 s, System: 12.361 s]
  Range (min … max):   24.827 s … 26.561 s    10 runs

Benchmark 2: ../../npmi-go.new -force
  Time (mean ± σ):     17.822 s ±  1.277 s    [User: 26.564 s, System: 12.374 s]
  Range (min … max):   16.920 s … 21.050 s    10 runs

Summary
  '../../npmi-go.new -force' ran
    1.44 ± 0.11 times faster than '../../npmi-go.old -force'
```

## Cache HIT performance improvements.

```
npmi-go/bench/extract$ hyperfine -w5 ../../npmi-go.old ../../npmi-go.new
Benchmark 1: ../../npmi-go.old
  Time (mean ± σ):      2.913 s ±  0.043 s    [User: 2.800 s, System: 1.102 s]
  Range (min … max):    2.860 s …  2.978 s    10 runs

Benchmark 2: ../../npmi-go.new
  Time (mean ± σ):      1.161 s ±  0.101 s    [User: 1.496 s, System: 0.547 s]
  Range (min … max):    1.036 s …  1.292 s    10 runs

Summary
  '../../npmi-go.new' ran
   2.51 ± 0.22 times faster than '../../npmi-go.old'
```